### PR TITLE
Handle data path robustly

### DIFF
--- a/qvae.py
+++ b/qvae.py
@@ -194,7 +194,12 @@ def main(args: argparse.Namespace):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="QVAE demo")
-    parser.add_argument("--csv", type=Path, default=Path("crc_consolidated.csv"), help="Input data CSV")
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=Path(__file__).resolve().parent / "crc_consolidated.csv",
+        help="Input data CSV",
+    )
     parser.add_argument("--epochs", type=int, default=5)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--qubits", type=int, default=4, help="Number of qubits/latent dimensions")


### PR DESCRIPTION
## Summary
- make crcClean resolve the download directory relative to the script and expose CLI options for input and output paths
- update qvae default CSV location to match crcClean output

## Testing
- `python -m py_compile crcClean.py qvae.py`
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python crcClean.py --data-dir GDC_download/59ee330e-3e39-4a92-b4fb-efc732d71681 --output /tmp/test.csv` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python qvae.py --epochs 1 --features 2` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_688d38a019f88325abc87556616c372c